### PR TITLE
fix_set_actor_component_owner

### DIFF
--- a/Source/CoreExtensions/Private/BlueprintLibraries/CoreExtHelperBlueprintLibrary.cpp
+++ b/Source/CoreExtensions/Private/BlueprintLibraries/CoreExtHelperBlueprintLibrary.cpp
@@ -151,7 +151,7 @@ void UCoreExtHelperBlueprintLibrary::SetActorComponentOwner( UActorComponent * c
 {
     if ( component != nullptr && new_owner_actor != nullptr )
     {
-        const auto new_name = MakeUniqueObjectName(new_owner_actor, component->GetClass(), *component->GetName());
+        const auto new_name = MakeUniqueObjectName( new_owner_actor, component->GetClass(), *component->GetName() );
         component->Rename( *new_name.ToString(), new_owner_actor );
     }
 }

--- a/Source/CoreExtensions/Private/BlueprintLibraries/CoreExtHelperBlueprintLibrary.cpp
+++ b/Source/CoreExtensions/Private/BlueprintLibraries/CoreExtHelperBlueprintLibrary.cpp
@@ -151,6 +151,7 @@ void UCoreExtHelperBlueprintLibrary::SetActorComponentOwner( UActorComponent * c
 {
     if ( component != nullptr && new_owner_actor != nullptr )
     {
-        component->Rename( *component->GetName(), new_owner_actor );
+        const auto new_name = MakeUniqueObjectName(new_owner_actor, component->GetClass(), *component->GetName());
+        component->Rename( *new_name.ToString(), new_owner_actor );
     }
 }


### PR DESCRIPTION
make component new name unique so avoid fatal crash from the engine when we try to rename an existing object (for example : components as VFX that's are pooled)